### PR TITLE
[feat] 피드백 생성 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ hs_err_pid*
 replay_pid*
 
 .idea/
-backend/src/main/resources/*.properties
+*.properties
 backend/build
 backend/.gradle

--- a/backend/src/main/java/com/startingblue/dailypainting/diary/exception/DiaryException.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/diary/exception/DiaryException.java
@@ -1,0 +1,5 @@
+package com.startingblue.dailypainting.diary.exception;
+
+public final class DiaryException {
+
+}

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/controller/FeedbackController.java
@@ -1,7 +1,26 @@
 package com.startingblue.dailypainting.feedback.controller;
 
+import com.startingblue.dailypainting.feedback.dto.FeedbackSaveRequest;
+import com.startingblue.dailypainting.feedback.service.FeedbackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public final class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping("/api/feedbacks")
+    public ResponseEntity<Integer> createFeedback(@RequestBody final FeedbackSaveRequest feedbackSaveRequest){
+        feedbackService.save(feedbackSaveRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
@@ -8,7 +8,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public final class Feedback {
 
@@ -36,9 +39,6 @@ public final class Feedback {
 
     @OneToOne
     private Diary diary;
-
-    public Feedback() {
-    }
 
     public Feedback(final Long id, final int serviceSatisfaction, final int imageQuality, final int imageSatisfaction, final String comment, final String favoriteCharacter, final Diary diary) {
         this.id = id;

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
@@ -1,4 +1,59 @@
 package com.startingblue.dailypainting.feedback.domain;
 
+import com.startingblue.dailypainting.diary.domain.Diary;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+@Entity
 public final class Feedback {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Min(1)
+    @Max(5)
+    private int serviceSatisfaction;
+
+    @Min(1)
+    @Max(5)
+    private int imageQuality;
+
+    @Min(1)
+    @Max(5)
+    private int imageSatisfaction;
+
+    private String comment;
+
+    private String favoriteCharacter;
+
+    @OneToOne
+    private Diary diary;
+
+    public Feedback() {
+    }
+
+    public Feedback(final Long id, final int serviceSatisfaction, final int imageQuality, final int imageSatisfaction, final String comment, final String favoriteCharacter, final Diary diary) {
+        this.id = id;
+        this.serviceSatisfaction = serviceSatisfaction;
+        this.imageQuality = imageQuality;
+        this.imageSatisfaction = imageSatisfaction;
+        this.comment = comment;
+        this.favoriteCharacter = favoriteCharacter;
+        this.diary = diary;
+    }
+
+    public Feedback(final int serviceSatisfaction, final int imageQuality, final int imageSatisfaction, final String comment, final String favoriteCharacter, final Diary diary) {
+        this.id = -1L;
+        this.serviceSatisfaction = serviceSatisfaction;
+        this.imageQuality = imageQuality;
+        this.imageSatisfaction = imageSatisfaction;
+        this.comment = comment;
+        this.favoriteCharacter = favoriteCharacter;
+        this.diary = diary;
+    }
 }

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/domain/Feedback.java
@@ -1,6 +1,7 @@
 package com.startingblue.dailypainting.feedback.domain;
 
 import com.startingblue.dailypainting.diary.domain.Diary;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -27,8 +28,10 @@ public final class Feedback {
     @Max(5)
     private int imageSatisfaction;
 
+    @Column(length = 500)
     private String comment;
 
+    @Column(length = 500)
     private String favoriteCharacter;
 
     @OneToOne

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/dto/FeedbackSaveRequest.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/dto/FeedbackSaveRequest.java
@@ -1,0 +1,21 @@
+package com.startingblue.dailypainting.feedback.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public final class FeedbackSaveRequest {
+
+    private final int serviceSatisfaction;
+
+    private final int imageQuality;
+
+    private final int imageSatisfaction;
+
+    private final String comment;
+
+    private final String favoriteCharacter;
+
+    private final Long diaryId;
+}

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/exception/FeedbackException.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/exception/FeedbackException.java
@@ -1,0 +1,5 @@
+package com.startingblue.dailypainting.feedback.exception;
+
+public final class FeedbackException {
+
+}

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/service/FeedbackService.java
@@ -7,10 +7,12 @@ import com.startingblue.dailypainting.feedback.domain.FeedbackRepository;
 import com.startingblue.dailypainting.feedback.dto.FeedbackSaveRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
-public final class FeedbackService {
+public class FeedbackService {
 
     private static final String DIARY_NOT_FOUND_EXCEPTION_MESSAGE = "존재하지 않는 일기";
     private final FeedbackRepository feedbackRepository;

--- a/backend/src/main/java/com/startingblue/dailypainting/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/feedback/service/FeedbackService.java
@@ -1,7 +1,33 @@
 package com.startingblue.dailypainting.feedback.service;
 
+import com.startingblue.dailypainting.diary.domain.Diary;
+import com.startingblue.dailypainting.diary.domain.DiaryRepository;
+import com.startingblue.dailypainting.feedback.domain.Feedback;
+import com.startingblue.dailypainting.feedback.domain.FeedbackRepository;
+import com.startingblue.dailypainting.feedback.dto.FeedbackSaveRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
 @Service
 public final class FeedbackService {
+
+    private static final String DIARY_NOT_FOUND_EXCEPTION_MESSAGE = "존재하지 않는 일기";
+    private final FeedbackRepository feedbackRepository;
+    private final DiaryRepository diaryRepository;
+
+    public void save(final FeedbackSaveRequest feedbackSaveRequest) {
+
+        final Diary diary = diaryRepository.findById(feedbackSaveRequest.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException(DIARY_NOT_FOUND_EXCEPTION_MESSAGE));
+        final Feedback feedback = new Feedback(
+                feedbackSaveRequest.getServiceSatisfaction(),
+                feedbackSaveRequest.getImageQuality(),
+                feedbackSaveRequest.getImageSatisfaction(),
+                feedbackSaveRequest.getComment(),
+                feedbackSaveRequest.getFavoriteCharacter(),
+                diary);
+
+        feedbackRepository.save(feedback);
+    }
 }

--- a/backend/src/main/java/com/startingblue/dailypainting/member/exception/MemberException.java
+++ b/backend/src/main/java/com/startingblue/dailypainting/member/exception/MemberException.java
@@ -1,0 +1,5 @@
+package com.startingblue.dailypainting.member.exception;
+
+public final class MemberException {
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=dailypainting


### PR DESCRIPTION
# [feat] 피드백 생성 api 구현
### Pull Request 타입
- [ ] bug
- [x] feat
- [ ] style
- [ ] refactor(기능 변경 없음)
- [ ] build
- [ ] CI/CD
- [ ] doc
- [ ] chore

### TSK-60
---
* 구현 내용
.gitignore가 .properties를 추적하지 않도록 수정
application.properties 삭제
피드백 입력 api구현
별점은 1~5점, 추가 의견은 최대 500글자, 좋아하는 캐릭터는 최대 500글자로 제한
각 도메인용 커스텀 예외 클래스 추가


* 추가 발생한 문제

